### PR TITLE
HOTFIX: test coverage increased

### DIFF
--- a/CMUPoll.xcodeproj/xcshareddata/xcschemes/CMUPoll.xcscheme
+++ b/CMUPoll.xcodeproj/xcshareddata/xcschemes/CMUPoll.xcscheme
@@ -27,8 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      codeCoverageEnabled = "YES">
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/CMUPoll/Models/ModelParser.swift
+++ b/CMUPoll/Models/ModelParser.swift
@@ -29,7 +29,14 @@ class ModelParser {
 //        let link: String = (obj["link"] ?? "") as! String // Disabled
         let is_private: Bool = obj["private"] as! Bool
         let is_closed: Bool = obj["closed"] as! Bool
-        let passcode: String? = obj["passcode"] == nil ? nil : obj["passcode"] as? String
+        var passcode: String?
+        if obj["passcode"] == nil {
+          passcode = nil
+        } else if "\(String(describing: obj["passcode"]!))" == "<null>" {
+          passcode = nil
+        } else {
+          passcode = "\(String(describing: obj["passcode"]!))"
+        }
         let poll = Poll(id: id, user_id: user_id, title: title, description: description, posted_at: posted_at, link: "", is_private: is_private, is_closed: is_closed, passcode: passcode)
         result.append(poll)
         break
@@ -59,7 +66,14 @@ class ModelParser {
         let content: String = obj["content"] as! String
         let posted_at: String = obj["posted_at"] as! String
         let user_id: String = "\(String(describing: obj["user_id"]!))"
-        let comment_id: String? = obj["comment_id"] == nil ? nil : "\(String(describing: obj["comment_id"]!))"
+        var comment_id: String?
+        if obj["comment_id"] == nil {
+          comment_id = nil
+        } else if "\(String(describing: obj["comment_id"]!))" == "<null>" {
+          comment_id = nil
+        } else {
+          comment_id = "\(String(describing: obj["comment_id"]!))"
+        }
         let poll_id: String = "\(String(describing: obj["poll_id"]!))"
         let comment = Comment(id: id, content: content, posted_at: posted_at, user_id: user_id, comment_id: comment_id, poll_id: poll_id)
         result.append(comment)

--- a/CMUPoll/Models/PollTag.swift
+++ b/CMUPoll/Models/PollTag.swift
@@ -24,11 +24,20 @@ struct PollTag: Identifiable {
   // NOTE: Used to initialize a completely new instance and to upload to Firebase
   static func create(poll_id: String, tag_id: String, completion: @escaping (PollTag) -> ()) {
     let colRef = FirebaseDataHandler.colRef(collection: .polltag)
-    let data: [String:Any] = ["poll_id": poll_id, "tag_id": tag_id]
-    FirebaseDataHandler.add(colRef: colRef, data: data, completion: { documentId in
-      let polltag = PollTag(id: documentId, poll_id: poll_id, tag_id: tag_id)
-      completion(polltag)
-    })
+    
+    let query = colRef
+      .whereField("poll_id", isEqualTo: poll_id)
+      .whereField("tag_id", isEqualTo: tag_id)
+    
+    FirebaseDataHandler.get(query: query) { result in
+      if result.isEmpty {
+        let data: [String:Any] = ["poll_id": poll_id, "tag_id": tag_id]
+        FirebaseDataHandler.add(colRef: colRef, data: data, completion: { documentId in
+          let polltag = PollTag(id: documentId, poll_id: poll_id, tag_id: tag_id)
+          completion(polltag)
+        })
+      }
+    }
   }
   
   static func withId(id: String, completion: @escaping (PollTag?) -> ()) {

--- a/CMUPollTests/CommentTests.swift
+++ b/CMUPollTests/CommentTests.swift
@@ -43,7 +43,7 @@ class CommentTests: XCTestCase {
   func testInitializeComments() {
     XCTAssertEqual(Comment0!.id, "0")
     XCTAssertEqual(Comment0!.user_id, "0")
-    XCTAssertEqual(Comment0?.comment_id, "NULL")
+    XCTAssertEqual(Comment0!.comment_id, nil)
     XCTAssertEqual(Comment0!.poll_id, "0")
     XCTAssertEqual(Comment0!.content, "I agree with you! I love underground!")
     

--- a/CMUPollTests/PollTests.swift
+++ b/CMUPollTests/PollTests.swift
@@ -220,6 +220,13 @@ class PollTests: XCTestCase {
     self.waitForExpectations(timeout: 5.0, handler: nil)
   }
   
+  func testCreateInvalid() {
+    User.current = nil
+    Poll.create(title: "Test title", description: "Test description", link: "", is_private: false, is_closed: false, passcode: nil) { poll in
+      XCTAssertTrue(false)
+    }
+  }
+    
   func testCreateUpdateDelete() {
     let expectation = self.expectation(description: "Test create update delete")
     
@@ -230,9 +237,10 @@ class PollTests: XCTestCase {
         XCTAssertEqual("test description", poll.description)
         XCTAssertEqual(false, poll.is_private)
         XCTAssertEqual(true, poll.is_closed)
-        poll.update(user_id: nil, title: "new title", description: nil, link: nil, is_closed: false, is_private: true, passcode: "0505") {
+        poll.update(user_id: nil, title: "new title", description: "new description", link: "new link", is_closed: false, is_private: true, passcode: "0505") {
           XCTAssertEqual("new title", poll.title)
-          XCTAssertEqual("test description", poll.description)
+          XCTAssertEqual("new description", poll.description)
+          XCTAssertEqual("new link", poll.link)
           XCTAssertEqual(true, poll.is_private)
           XCTAssertEqual(false, poll.is_closed)
           poll.delete {
@@ -242,5 +250,21 @@ class PollTests: XCTestCase {
       }
     }
     self.waitForExpectations(timeout: 5.0, handler: nil)
+  }
+  
+  func testAddTag() {
+    User.withId(id: "5") { user in
+      User.current = user
+      Poll.withId(id: "9") { poll in
+        poll!.addTags(tagNames: ["Life", "Freshman"])
+      }
+    }
+  }
+  
+  func testAddTagInvalid() {
+    User.current = nil
+    Poll.withId(id: "9") { poll in
+      poll!.addTags(tagNames: ["Life", "Freshman"])
+    }
   }
 }

--- a/CMUPollTests/UserTests.swift
+++ b/CMUPollTests/UserTests.swift
@@ -14,7 +14,7 @@ import Firebase
 class UserTests: XCTestCase {
   var colRef: CollectionReference?
   var users: [User]?
-  var User0, User1, User2: User?
+  var User0, User1, User2, User4: User?
   
   func setUser0() {
     let expectation = self.expectation(description: "Initialize users")
@@ -43,12 +43,22 @@ class UserTests: XCTestCase {
     self.waitForExpectations(timeout: 5.0, handler: nil)
   }
   
+  func setUser4() {
+    let expectation = self.expectation(description: "Initialize users")
+    User.withId(id: "4", completion: { user in
+      self.User4 = user
+      expectation.fulfill()
+    })
+    self.waitForExpectations(timeout: 5.0, handler: nil)
+  }
+  
   override func setUp() {
     super.setUp()
     self.colRef = FirebaseDataHandler.colRef(collection: .user)
     setUser0()
     setUser1()
     setUser2()
+    setUser4()
   }
   
   func testInitializeUsers() {
@@ -72,6 +82,8 @@ class UserTests: XCTestCase {
     XCTAssertEqual(User2!.email, "sunghocho@andrew.cmu.edu")
     XCTAssertEqual(User2!.major, "Information Systems")
     XCTAssertEqual(User2!.graduation_year, 2020)
+    
+    XCTAssertNil(User4!.graduation_year)
   }
   
   func testAddPoints0() {
@@ -151,15 +163,25 @@ class UserTests: XCTestCase {
       XCTAssertEqual("Doe", user.last_name)
       XCTAssertEqual("Psychology", user.major)
       XCTAssertEqual(2010, user.graduation_year)
-      user.update(major: "Math", graduation_year: nil, points: nil) {
+      user.update(major: "Math", graduation_year: 2011, points: 500) {
         XCTAssertEqual("John", user.first_name)
         XCTAssertEqual("Doe", user.last_name)
         XCTAssertEqual("Math", user.major)
-        XCTAssertEqual(2010, user.graduation_year)
+        XCTAssertEqual(2011, user.graduation_year)
+        XCTAssertEqual(500, user.points)
         user.delete {
           expectation.fulfill()
         }
       }
+    }
+    self.waitForExpectations(timeout: 5.0, handler: nil)
+  }
+  
+  func testWithIdInvalid() {
+    let expectation = self.expectation(description: "Test withId")
+    User.withId(id: "9999999") { user in
+      XCTAssertNil(user)
+      expectation.fulfill()
     }
     self.waitForExpectations(timeout: 5.0, handler: nil)
   }


### PR DESCRIPTION
To increase test coverage upto 90% for model files, we added new test cases (poll's addTags, reset current user to a null value, optional value handling, preventing from tag & pollTag getting created when poll's addTag function is triggered)