### PR TITLE
QUICKFIX- poll's title text is not truncated in answerboxview

### DIFF
--- a/CMUPoll/Views/AnswerBoxView.swift
+++ b/CMUPoll/Views/AnswerBoxView.swift
@@ -103,6 +103,7 @@ struct AnswerBoxTextView: View {
       .font(Font.system(size: 20, design: .default))
       .fontWeight(.semibold)
       .foregroundColor(Color(red: 91 / 255.0, green: 91 / 255.0, blue: 91 / 255.0, opacity: 1.0))
+      .fixedSize(horizontal: false, vertical: true)
   }
 }
 


### PR DESCRIPTION
- Included 1 line to fix the issue that the poll title gets truncated 